### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup, find_packages
+
+
+requirements = ['pycrypto>=2.6.1']
+
+
+setup(
+    name="ziggeo",
+    version="1.0",
+    description="Ziggeo SDK for python",
+    url="http://github.com/Ziggeo/ZiggeoPythonSdk",
+    license="Apache 2.0",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache 2.0 License",
+        "Programming Language :: Python :: 2.7",
+    ],
+    keywords=("Ziggeo video-upload"),
+    packages=find_packages(),
+    install_requires=requirements,
+)


### PR DESCRIPTION
In refernce to #2.

Still not listed on `pypi`, but once merged, you can now install via, 

```bash
pip install -e git+git@github.com:ziggeo/ZiggeoPythonSdk.git#egg=ziggeo
```

to test at the moment, 
```bash
pip install -e git+git@github.com:dubizzle/ZiggeoPythonSdk.git@add_setup#egg=ziggeo
```